### PR TITLE
#2 - Login

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
+import { BrowserRouter, Switch, Route, Redirect, Link } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { SnackbarProvider } from 'notistack';
 import AuthState from './containers/AuthState';
@@ -8,6 +8,7 @@ import Home from './components/Home';
 import Profile from './components/Profile';
 import Signup from './containers/SignupWithData';
 import Login from './containers/LoginWithData';
+import Logout from './containers/Logout';
 
 import DataProvider from './providers/DataProvider';
 import ThemeProvider from './providers/ThemeProvider';
@@ -24,18 +25,48 @@ const App = () => (
                     <SnackbarProvider
                       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
                     >
-                      <h1>Logged In!</h1>
-                      <Switch>
-                        <Route exact path="/" component={Home} />
-                        <Route exact path="/signup" component={Signup} />
-                        <Route exact path="/login" component={Login} />
-                        <Route exact path="/profile" component={Profile} />
-                      </Switch>
+                      <React.Fragment>
+                        <h1>Logged In!</h1>
+                          <Logout>
+                              { props => (
+                                <a
+                                  href="#"
+                                  style={{
+                                    'fontSize': '20px',
+                                    'color': 'blue',
+                                  }}
+                                  onClick={ e => {
+                                     props.handleLogout();
+                                }}>
+                                  Log Out
+                                </a>
+                              )}
+                          </Logout>
+                        <Switch>
+                          <Route exact path="/" component={Home} />
+                          <Route exact path="/signup" component={Signup} />
+                          <Route
+                            exact
+                            path="/login"
+                            render={ () => (
+                              <Redirect
+                                to={{
+                                  pathname: '/'
+                                }}
+                              />
+                            )}
+                          />
+                          <Route exact path="/profile" component={Profile} />
+                        </Switch>
+                      </React.Fragment>
                     </SnackbarProvider>
                 }
                 { !isAuthenticated &&
                   <React.Fragment>
                   <h1>Logged Out!</h1>
+                  <Link to="/login">
+                    Login
+                  </Link>
                   <Switch>
                     <Route exact path="/" component={Home} />
                     <Route exact path="/signup" component={Signup} />
@@ -43,7 +74,7 @@ const App = () => (
                     <Route
                       exact
                       path="/profile"
-                      render={props => (
+                      render={ () => (
                         <Redirect
                           to={{
                             pathname: '/'

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -2,42 +2,61 @@ import React from 'react';
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { SnackbarProvider } from 'notistack';
+import AuthState from './containers/AuthState';
+
 import Home from './components/Home';
 import Profile from './components/Profile';
 import Signup from './containers/SignupWithData';
+import Login from './containers/LoginWithData';
 
 import DataProvider from './providers/DataProvider';
 import ThemeProvider from './providers/ThemeProvider';
 
-const App = ({ auth = { isAuthenticated: true }}) => (
+const App = () => (
   <BrowserRouter>
     <CssBaseline>
       <DataProvider>
         <ThemeProvider>
-          <SnackbarProvider
-            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-          >
-            <Switch>
-              <Route exact path="/" component={Home} />
-              <Route exact path="/signup" component={Signup} />
-              <Route exact path="/profile" component={Profile} />
-              <Route
-                exact
-                path="/profile"
-                render={props =>
-                  auth.isAuthenticated() ? (
-                    <Profile />
-                  ) : (
-                    <Redirect
-                      to={{
-                        pathname: '/'
-                      }}
-                    />
-                  )
+          <AuthState>
+            {({ isAuthenticated }) => (
+              <React.Fragment>
+                { isAuthenticated &&
+                    <SnackbarProvider
+                      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                    >
+                      <h1>Logged In!</h1>
+                      <Switch>
+                        <Route exact path="/" component={Home} />
+                        <Route exact path="/signup" component={Signup} />
+                        <Route exact path="/login" component={Login} />
+                        <Route exact path="/profile" component={Profile} />
+                      </Switch>
+                    </SnackbarProvider>
                 }
-              />
-            </Switch>
-          </SnackbarProvider>
+                { !isAuthenticated &&
+                  <React.Fragment>
+                  <h1>Logged Out!</h1>
+                  <Switch>
+                    <Route exact path="/" component={Home} />
+                    <Route exact path="/signup" component={Signup} />
+                    <Route exact path="/login" component={Login} />
+                    <Route
+                      exact
+                      path="/profile"
+                      render={props => (
+                        <Redirect
+                          to={{
+                            pathname: '/'
+                          }}
+                        />
+                      )}
+                    />
+                  </Switch>
+                  </React.Fragment>
+                }
+              </React.Fragment>
+            )}
+          </AuthState>
         </ThemeProvider>
       </DataProvider>
     </CssBaseline>

--- a/app/src/components/Home.js
+++ b/app/src/components/Home.js
@@ -3,6 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { compose } from 'recompose';
 import FeedData from '../containers/FeedData';
 import FeedSubscriptionData from '../containers/FeedSubscriptionData';
+import AuthState from '../containers/AuthState';
 import ListComments from './ListComments';
 import Notice from './Notice';
 
@@ -19,10 +20,17 @@ const enhanced = compose(withStyles(styles));
 
 export default enhanced(({ classes }) => (
   <div className={classes.page}>
-    <FeedSubscriptionData>
-      {props => <Notice {...props} />}
-    </FeedSubscriptionData>
-
+    <AuthState>
+      {({ isAuthenticated }) => (
+        <React.Fragment>
+          { isAuthenticated &&
+            <FeedSubscriptionData>
+              {props => <Notice {...props} />}
+            </FeedSubscriptionData>
+          }
+        </React.Fragment>
+      )}
+    </AuthState>
     <FeedData>{props => <ListComments {...props} />}</FeedData>
   </div>
 ));

--- a/app/src/components/Login.js
+++ b/app/src/components/Login.js
@@ -10,7 +10,7 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
 
 const styles = theme => ({
-  signupContainer: {
+  loginContainer: {
     margin: '250px auto 0 auto',
     width: '50%',
     maxWidth: 400,
@@ -20,7 +20,7 @@ const styles = theme => ({
     marginTop: 30,
   },
   [theme.breakpoints.down('sm')]: {
-    signupContainer: {
+    loginContainer: {
       margin: '50px auto 0 auto',
       width: '90%',
     },
@@ -32,7 +32,6 @@ const styles = theme => ({
 
 const enhance = compose(
   withStyles(styles),
-  withState('formErrorName', 'setFormErrorName', null),
   withState('formErrorEmail', 'setFormErrorEmail', null),
   withState('formErrorPassword', 'setFormErrorPassword', null),
   withState('formErrorOther', 'setFormErrorOther', null)
@@ -41,39 +40,33 @@ const enhance = compose(
 export default enhance(({
   classes,
   onSubmit,
-  name,
   email,
 
-  onNameChange,
   onEmailChange,
   onPasswordChange,
 
-  formErrorName,
   formErrorEmail,
   formErrorPassword,
   formErrorOther,
 
-  setFormErrorName,
   setFormErrorEmail,
   setFormErrorPassword,
   setFormErrorOther,
 }) => (
-    <Card className={classes.signupContainer}>
+    <Card className={classes.loginContainer}>
       <CardContent>
         <Typography variant="h5">
-          Sign Up
+          Log In
         </Typography>
         <form
           onSubmit={ e => {
             e.preventDefault();
-            setFormErrorName(null);
             setFormErrorEmail(null);
             setFormErrorPassword(null);
             setFormErrorOther(null);
             if (onSubmit) {
               onSubmit({
                 variables: {
-                  name: e.target.name.value,
                   email: e.target.email.value,
                   password: e.target.password.value
                 }
@@ -82,9 +75,6 @@ export default enhance(({
                 if(e.errors) {
                   for (let error of e.errors) {
                     switch(error[0]) {
-                      case 'name':
-                        setFormErrorName(error[1]);
-                      break;
                       case 'email':
                         setFormErrorEmail(error[1]);
                       break;
@@ -105,22 +95,6 @@ export default enhance(({
             }
           }}
         >
-        <FormControl
-          error={formErrorName !== null}
-          fullWidth
-          className={classes.input}
-        >
-          <Input
-            type="text"
-            placeholder="Name"
-            name="name"
-            defaultValue={name}
-            required={true}
-          />
-          <FormHelperText>
-            {formErrorName}
-          </FormHelperText>
-        </FormControl>
         <FormControl
           error={formErrorEmail !== null}
           fullWidth
@@ -160,7 +134,7 @@ export default enhance(({
           <div>
             <br />
             <Button type="submit" variant="contained" color="primary" className={classes.margin}>
-            Sign Up
+            Log In
             </Button>
           </div>
         </form>

--- a/app/src/components/Login.js
+++ b/app/src/components/Login.js
@@ -8,6 +8,7 @@ import Input from '@material-ui/core/Input';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
+import LinearProgress from '@material-ui/core/LinearProgress';
 
 const styles = theme => ({
   loginContainer: {
@@ -34,7 +35,8 @@ const enhance = compose(
   withStyles(styles),
   withState('formErrorEmail', 'setFormErrorEmail', null),
   withState('formErrorPassword', 'setFormErrorPassword', null),
-  withState('formErrorOther', 'setFormErrorOther', null)
+  withState('formErrorOther', 'setFormErrorOther', null),
+  withState('loginLoading', 'setLoginLoading', null),
 );
 
 export default enhance(({
@@ -48,12 +50,22 @@ export default enhance(({
   formErrorEmail,
   formErrorPassword,
   formErrorOther,
+  loginLoading,
 
   setFormErrorEmail,
   setFormErrorPassword,
   setFormErrorOther,
+  setLoginLoading
 }) => (
     <Card className={classes.loginContainer}>
+      { loginLoading &&
+        <LinearProgress />
+      }
+      { !loginLoading &&
+        /* quick hack to prevent visual offset when loading indicator shows */
+        <div style={{ height: 5 }} />
+      }
+
       <CardContent>
         <Typography variant="h5">
           Log In
@@ -65,6 +77,7 @@ export default enhance(({
             setFormErrorPassword(null);
             setFormErrorOther(null);
             if (onSubmit) {
+              setLoginLoading(true);
               onSubmit({
                 variables: {
                   email: e.target.email.value,
@@ -85,12 +98,14 @@ export default enhance(({
                         setFormErrorOther(error[1]);
                     }
                   }
+                  setLoginLoading(false);
                 }
               })
               .catch( e => {
                 if(e.errors) {
                   setFormErrorOther(e.errors);
                 }
+                setLoginLoading(false);
               });
             }
           }}
@@ -133,7 +148,7 @@ export default enhance(({
         </FormControl>
           <div>
             <br />
-            <Button type="submit" variant="contained" color="primary" className={classes.margin}>
+            <Button disabled={loginLoading} type="submit" variant="contained" color="primary" className={classes.margin}>
             Log In
             </Button>
           </div>

--- a/app/src/components/Signup.js
+++ b/app/src/components/Signup.js
@@ -8,6 +8,7 @@ import Input from '@material-ui/core/Input';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
+import LinearProgress from '@material-ui/core/LinearProgress';
 
 const styles = theme => ({
   signupContainer: {
@@ -35,7 +36,8 @@ const enhance = compose(
   withState('formErrorName', 'setFormErrorName', null),
   withState('formErrorEmail', 'setFormErrorEmail', null),
   withState('formErrorPassword', 'setFormErrorPassword', null),
-  withState('formErrorOther', 'setFormErrorOther', null)
+  withState('formErrorOther', 'setFormErrorOther', null),
+  withState('signupLoading', 'setSignupLoading', null),
 );
 
 export default enhance(({
@@ -52,13 +54,23 @@ export default enhance(({
   formErrorEmail,
   formErrorPassword,
   formErrorOther,
+  signupLoading,
 
   setFormErrorName,
   setFormErrorEmail,
   setFormErrorPassword,
   setFormErrorOther,
+  setSignupLoading,
 }) => (
     <Card className={classes.signupContainer}>
+      { signupLoading &&
+        <LinearProgress />
+      }
+      { !signupLoading &&
+        /* quick hack to prevent visual offset when loading indicator shows */
+        <div style={{ height: 5 }} />
+      }
+
       <CardContent>
         <Typography variant="h5">
           Sign Up
@@ -71,6 +83,7 @@ export default enhance(({
             setFormErrorPassword(null);
             setFormErrorOther(null);
             if (onSubmit) {
+              setSignupLoading(true);
               onSubmit({
                 variables: {
                   name: e.target.name.value,
@@ -96,11 +109,13 @@ export default enhance(({
                     }
                   }
                 }
+                setSignupLoading(false);
               })
               .catch( e => {
                 if(e.errors) {
                   setFormErrorOther(e.errors);
                 }
+                setSignupLoading(false);
               });
             }
           }}
@@ -116,6 +131,7 @@ export default enhance(({
             name="name"
             defaultValue={name}
             required={true}
+            onChange={onNameChange}
           />
           <FormHelperText>
             {formErrorName}
@@ -159,7 +175,7 @@ export default enhance(({
         </FormControl>
           <div>
             <br />
-            <Button type="submit" variant="contained" color="primary" className={classes.margin}>
+            <Button disabled={signupLoading} type="submit" variant="contained" color="primary" className={classes.margin}>
             Sign Up
             </Button>
           </div>

--- a/app/src/containers/AuthState.js
+++ b/app/src/containers/AuthState.js
@@ -1,0 +1,16 @@
+import { graphql } from 'react-apollo';
+import { compose, withProps, toRenderProps } from 'recompose';
+import ClientLoggedInQuery from '../gqlqueries/ClientLoggedIn';
+
+const enhanced = compose(
+  graphql(ClientLoggedInQuery,{
+    props: ({ data : { auth }}) => ({
+      isAuthenticated: auth && sessionStorage.getItem('userToken') && auth.isAuthenticated
+    })
+  }),
+  withProps(({ auth, setAuth } ) => ({
+    auth
+  }))
+);
+
+export default toRenderProps(enhanced);

--- a/app/src/containers/FeedData.js
+++ b/app/src/containers/FeedData.js
@@ -1,19 +1,9 @@
 import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
 import { compose, withProps, toRenderProps } from 'recompose';
-
-const query = gql`
-  query feed {
-    feed {
-      id
-      message
-      createdAt
-    }
-  }
-`;
+import FeedDataQuery from '../gqlqueries/FeedData';
 
 const enhanced = compose(
-  graphql(query),
+  graphql(FeedDataQuery),
   withProps(({ data: { loading, feed } }) => ({
     loading: loading,
     comments: feed

--- a/app/src/containers/FeedSubscriptionData.js
+++ b/app/src/containers/FeedSubscriptionData.js
@@ -1,26 +1,9 @@
 import { graphql } from 'react-apollo';
-import gql from 'graphql-tag';
 import { compose, withProps, toRenderProps } from 'recompose';
-
-const query = gql`
-  subscription {
-    feedSubscription {
-      mutation
-      node {
-        id
-        message
-        updatedAt
-      }
-      previousValues {
-        id
-        message
-      }
-    }
-  }
-`;
+import FeedSubscriptionQuery from '../gqlqueries/FeedSubscription';
 
 const enhanced = compose(
-  graphql(query),
+  graphql(FeedSubscriptionQuery),
   withProps(({ data: { feedSubscription } }) => {
     if (!feedSubscription) {
       return;

--- a/app/src/containers/LoginWithData.js
+++ b/app/src/containers/LoginWithData.js
@@ -35,6 +35,7 @@ const LoginMutation = props => {
       })
       .then(res => {
         sessionStorage.setItem('userToken', res.data.login.token);
+        props.history.push('/');
       })
       .catch( e => {
         return { errors: parseResponseError(e.graphQLErrors) };

--- a/app/src/containers/LoginWithData.js
+++ b/app/src/containers/LoginWithData.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { graphql, Mutation } from 'react-apollo';
+import { compose } from 'react-apollo';
+
+import Login from '../components/Login';
+import LoginQuery from '../gqlqueries/Login';
+
+// @TODO - due to time constraints unlikely to figure out
+// GraphQL custom error classes server side
+const addErrorType = err => {
+  switch(err.message) {
+    case 'Invalid password':
+      return ['password', err.message];
+    case 'No user with that email address':
+      return ['email', err.message];
+    default:
+      return ['unknown', 'An unknown error has occurred'];
+  }
+};
+
+const parseResponseError = errors => {
+  let allErrors = [];
+  for(let error of errors) {
+    allErrors.push(addErrorType(error));
+  }
+  return allErrors;
+};
+
+const LoginMutation = props => {
+  const { loginAction } = props;
+  const handleSubmit = data => {
+    if(data['variables']) {
+      return loginAction({
+        variables: data.variables
+      })
+      .then(res => {
+        sessionStorage.setItem('userToken', res.data.login.token);
+      })
+      .catch( e => {
+        return { errors: parseResponseError(e.graphQLErrors) };
+      });
+    }
+  };
+
+  return (
+    <Mutation mutation={LoginQuery}>
+      {() => (
+        <Login {...props} onSubmit={handleSubmit} />
+      )}
+    </Mutation>
+  );
+};
+
+export default compose(
+  graphql(LoginQuery, { name: 'loginAction' })
+)(LoginMutation);

--- a/app/src/containers/Logout.js
+++ b/app/src/containers/Logout.js
@@ -1,0 +1,20 @@
+import { graphql } from 'react-apollo';
+import { compose, withHandlers } from 'recompose';
+import LogoutQuery from '../gqlqueries/Logout';
+
+const handleLogout = ({ mutate }) => {
+  mutate({
+    variables: {isAuthenticated: false}
+  });
+  sessionStorage.removeItem('userToken');
+  window.__APOLLO_CLIENT__.resetStore();
+};
+
+export default compose(
+  graphql(LogoutQuery),
+  withHandlers({
+    handleLogout: props => event => {
+      handleLogout(props);
+    }
+  })
+)(({ children, ...props }) => children(props));

--- a/app/src/containers/SignupWithData.js
+++ b/app/src/containers/SignupWithData.js
@@ -52,6 +52,7 @@ const SignupMutation = props => {
         })
         .then(res => {
           sessionStorage.setItem('userToken', res.data.login.token);
+          props.history.push('/');
         })
         .catch( e => {
           return {error: 'invalid user credentials'};

--- a/app/src/gqlqueries/ClientLoggedIn.js
+++ b/app/src/gqlqueries/ClientLoggedIn.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  query {
+    auth @client {
+      isAuthenticated
+    }
+  }
+`;

--- a/app/src/gqlqueries/FeedData.js
+++ b/app/src/gqlqueries/FeedData.js
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  query feed {
+    feed {
+      id
+      message
+      createdAt
+    }
+  }
+`;

--- a/app/src/gqlqueries/FeedSubscription.js
+++ b/app/src/gqlqueries/FeedSubscription.js
@@ -1,0 +1,18 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  subscription {
+    feedSubscription {
+      mutation
+      node {
+        id
+        message
+        updatedAt
+      }
+      previousValues {
+        id
+        message
+      }
+    }
+  }
+`;

--- a/app/src/gqlqueries/Login.js
+++ b/app/src/gqlqueries/Login.js
@@ -1,20 +1,15 @@
 import gql from 'graphql-tag';
 
 export default gql`
-    mutation login($email: String!, $password: String!){
-      login(email: $email, password: $password){
-        token
-        user {
-          id
-          name
-          email
-        }
+  mutation login($email: String!, $password: String!){
+    login(email: $email, password: $password){
+      token
+      user {
+        id
+        name
+        email
+      }
 
-      }
-      setAuth (isAuthenticated: true) @client {
-        authStatus {
-          isAuthenticated
-        }
-      }
     }
+  }
 `;

--- a/app/src/gqlqueries/Logout.js
+++ b/app/src/gqlqueries/Logout.js
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation setAuth($isAuthenticated: Bool!){
+    setAuth (isAuthenticated: $isAuthenticated) @client {
+      auth {
+        isAuthenticated
+      }
+    }
+  }
+`;

--- a/app/src/gqlqueries/Signup.js
+++ b/app/src/gqlqueries/Signup.js
@@ -1,13 +1,13 @@
 import gql from 'graphql-tag';
 
 export default gql`
-    mutation signup($name: String!, $email: String!, $password: String!){
-      signup(name: $name email: $email password: $password) {
-        user {
-          id
-          name
-          email
-        }
+  mutation signup($name: String!, $email: String!, $password: String!){
+    signup(name: $name email: $email password: $password) {
+      user {
+        id
+        name
+        email
       }
     }
+  }
 `;

--- a/app/src/providers/DataProvider.js
+++ b/app/src/providers/DataProvider.js
@@ -11,8 +11,8 @@ import { withClientState } from 'apollo-link-state';
 
 const setAuth = (_, { isAuthenticated }, { cache }) => {
   const data = {
-    authStatus: {
-      __typename: 'AuthStatus',
+    auth: {
+      __typename: 'Auth',
       isAuthenticated
     },
   };
@@ -20,7 +20,6 @@ const setAuth = (_, { isAuthenticated }, { cache }) => {
   return null;
 };
 
-// TODO: via env configs
 const WS_URL = 'ws://localhost:4000';
 const HTTP_URL = 'http://localhost:4000';
 
@@ -41,7 +40,7 @@ const authLink = setContext((_, { headers }) => {
     return {
       headers: {
         ...headers,
-        authorization: token ? `Bearer ${token}` : "",
+        authorization: token ? `Bearer ${token}` : '',
       }
     }
   } else {
@@ -54,8 +53,8 @@ const authLink = setContext((_, { headers }) => {
 const cache = new InMemoryCache();
 
 const defaultState = {
-  authStatus: {
-    __typename: 'AuthStatus',
+  auth: {
+    __typename: 'Auth',
     isAuthenticated: !!sessionStorage.getItem('userToken'),
   }
 };
@@ -86,7 +85,7 @@ const client = new ApolloClient({
     stateLink,
     authLink,
     link
-        ])
+  ])
 });
 
 export default ({ children }) => (

--- a/app/src/providers/DataProvider.js
+++ b/app/src/providers/DataProvider.js
@@ -20,6 +20,17 @@ const setAuth = (_, { isAuthenticated }, { cache }) => {
   return null;
 };
 
+const setSignupLoading = (_, { loading }, { cache }) => {
+  const data = {
+    signupState: {
+      __typename: 'UiState',
+      loading
+    },
+  };
+  cache.writeData({ data });
+  return null;
+};
+
 const WS_URL = 'ws://localhost:4000';
 const HTTP_URL = 'http://localhost:4000';
 
@@ -63,7 +74,8 @@ const stateLink = withClientState({
   cache,
   resolvers: {
     Mutation: {
-      setAuth
+      setAuth,
+      setSignupLoading,
     },
   },
   defaults: defaultState


### PR DESCRIPTION
This is the login feature, which I chose to tackle after completing signup, since I knew login would use all of the same code and only require pruning of certain signup functionality.

Can be viewed at `/login`.

Adds the following features:

- [x] Adds login route + component + withData HOC / reuse & refactor signup code
- [x] Refactors server side `login` and `singnup` methods which were frustrating me due to being almost completely unvalidated
- [x] Adds `<AuthStatus />` HOC for conditional UI rendering dependent on client logged in state
- [x] Adds auto-redirection post log in and sign up, 
- [x] Adds loading indicator to `/signup` and `/login` forms for API calls re: form load state
- [x] Disables submit buttons while loading on `/signup` and `/login`
- [x] Refactors graphql queries to separate directory
- [x] Adds temporary visual logged in / out indication and buttons
