### PR TITLE
Comment CRUD + WSS connection

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -16,10 +16,10 @@ import { MuiThemeProvider } from '@material-ui/core/styles';
 import theme from './theme';
 
 const App = () => (
-  <BrowserRouter>
-    <CssBaseline>
-      <DataProvider>
-        <MuiThemeProvider theme={theme}>
+  <CssBaseline>
+    <DataProvider>
+      <MuiThemeProvider theme={theme}>
+        <BrowserRouter>
           <AuthState>
             {({ isAuthenticated }) => (
               <React.Fragment>
@@ -75,10 +75,10 @@ const App = () => (
               </React.Fragment>
             )}
           </AuthState>
-        </MuiThemeProvider>
-      </DataProvider>
-    </CssBaseline>
-  </BrowserRouter>
+        </BrowserRouter>
+      </MuiThemeProvider>
+    </DataProvider>
+  </CssBaseline>
 );
 
 export default App;

--- a/app/src/components/Comment.js
+++ b/app/src/components/Comment.js
@@ -1,29 +1,143 @@
 import React from 'react';
-import { compose } from 'recompose';
+import { compose, withState } from 'recompose';
 import TimeAgo from 'react-timeago';
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
+import Avatar from '@material-ui/core/Avatar';
+
+import PublicIcon from '@material-ui/icons/Public';
+import LockIcon from '@material-ui/icons/Lock';
+
+import AuthState from '../containers/AuthState';
+import EditComment from '../containers/EditCommentWithData';
+import Compose from '../components/Compose';
 
 const styles = theme => ({
   card: {
-    margin: theme.spacing.unit * 2,
-    maxWidth: 400
+    marginTop: theme.spacing.unit,
+    width: 400,
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+      flexShrink: 0,
+    },
+  },
+  commentCard: {
+    position: 'relative',
+  },
+  avatar: {
+    float: 'left',
+    marginRight: 10,
+  },
+  postVisibilityIcon: {
+    marginBottom: -4,
+    paddingTop: 3,
+    marginLeft: 10,
   }
 });
 
-const enhanced = compose(withStyles(styles));
+// @DISCLAIMER - I didn't write this helper fn, converting an arbitrary string
+// to a hex color is work done many times by folks on the internet ;)
+const stringToColor = str => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  let color = '#';
+  for (let i = 0; i < 3; i++) {
+    const value = (hash >> (i * 8)) & 0xFF;
+    color += ('00' + value.toString(16)).substr(-2);
+  }
+  return color;
+}
 
-export default enhanced(({ classes, message, createdAt }) => (
+const enhanced = compose(
+  withStyles(styles),
+  withState('editing', 'setEditing', false),
+);
+
+export default enhanced(({
+    classes,
+
+    id,
+    isPublic,
+    author,
+    message,
+    createdAt,
+
+    editing,
+    commentMsg,
+
+    refetch,
+    setEditing,
+    setCommentMsg,
+    onDeleteClick,
+    onCommentSave,
+  }) => {
+  return (
   <Card className={classes.card}>
-    <CardContent>
-      <Typography variant="subtitle1" color="textSecondary" gutterBottom>
+    <CardContent className={classes.commentCard}>
+      <AuthState>
+        {({ isAuthenticated, user }) => {
+          const userCanEdit = isAuthenticated &&
+            user.id.replace('User:','')
+            ===
+            author.id;
+          return (
+            <React.Fragment>
+              { userCanEdit &&
+                <EditComment
+                  author={author}
+                  id={id}
+                  isPublic={isPublic}
+                  message={message}
+                  refetch={refetch}
+                  editing={editing}
+                  commentMsg={commentMsg}
+                  setEditing={setEditing}
+                  setCommentMsg={setCommentMsg}
+
+                />
+              }
+            </React.Fragment>
+          )
+        }}
+      </AuthState>
+      <Avatar
+        className={classes.avatar}
+        style={{ backgroundColor: stringToColor(author.id) }}
+      >
+        {author.name.substring(0, 1)}
+      </Avatar>
+      <Typography>{author.name}</Typography>
+      <Typography color="textSecondary" gutterBottom>
         <TimeAgo date={createdAt} />
+        { isPublic &&
+          <PublicIcon className={classes.postVisibilityIcon} fontSize="small" />
+        }
+        { !isPublic &&
+          <LockIcon className={classes.postVisibilityIcon} fontSize="small" />
+        }
+
       </Typography>
-      <Typography variant="h5" component="h2">
-        {message}
-      </Typography>
+      { !editing &&
+        <Typography variant="h5" component="h2">
+          {message}
+        </Typography>
+      }
+      { editing &&
+        <Compose
+          id={id}
+          showInitally={isPublic}
+          key={`${id}${isPublic}`}
+          isPublic={isPublic}
+          message={message}
+          onCommentSave={onCommentSave}
+          refetch={refetch}
+          setEditing={setEditing}
+        />
+      }
     </CardContent>
   </Card>
-));
+)});

--- a/app/src/components/Compose.js
+++ b/app/src/components/Compose.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { compose, withState } from 'recompose';
+import { withStyles } from '@material-ui/core/styles';
+import FormControl from '@material-ui/core/FormControl';
+import Button from '@material-ui/core/Button';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import TextField from '@material-ui/core/TextField';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+
+const styles = theme => ({
+  composeForm: {
+    marginTop: 0,
+  }
+});
+
+const enhance = compose(
+  withStyles(styles),
+  withState('commentSaving', 'setCommentSaving', null),
+  withState('isPublicState', 'setIsPublicState', ({ showInitally }) => showInitally),
+);
+
+export default enhance(({
+  classes,
+
+  id,
+  isPublic,
+  message,
+  author,
+
+  onCommentSave,
+  commentSaving,
+  isPublicState,
+
+  setCommentSaving,
+  setIsPublicState,
+
+  setEditing,
+}) => {
+
+  const handleSwitchChange = e => {
+    setIsPublicState(!isPublicState);
+  };
+
+  return (
+    <React.Fragment>
+      <form
+        className={classes.composeForm}
+        onSubmit={ e => {
+          debugger;
+          e.preventDefault();
+          if (onCommentSave) {
+            setCommentSaving(true);
+            let variables;
+            // edit existing comments
+            if (id !== undefined) {
+              variables = {
+                id: id,
+                isPublic: isPublicState === undefined ? isPublic : isPublicState,
+                message: e.target.message.value,
+              }
+            // create new comments, stripping `id` key
+            } else {
+              variables = {
+                id: author.id.replace('User:', ''),
+                isPublic: isPublicState === undefined ? false : isPublicState,
+                message: e.target.message.value,
+              }
+            }
+            onCommentSave({
+              variables
+            })
+            .then(() => {
+              setCommentSaving(false);
+              setEditing(false);
+            })
+            .catch( e => {
+              setCommentSaving(false);
+            });
+          }
+        }}
+      >
+
+      <FormControl
+        fullWidth
+        className={classes.input}
+      >
+        <TextField
+          id="filled-textarea"
+          multiline
+          className={classes.textField}
+          margin="normal"
+          variant="filled"
+          name="message"
+          defaultValue={message}
+          required={true}
+          fullWidth
+        />
+        { commentSaving &&
+          <LinearProgress style={{ marginTop: -8 }} />
+        }
+        { !commentSaving &&
+          /* quick hack to prevent visual offset when loading indicator shows */
+          <div style={{ height: 5, marginTop: -8 }} />
+        }
+      </FormControl>
+
+      <FormControl
+        className={classes.input}
+      >
+      <FormControlLabel control={
+        <Switch
+          label="Public Comment"
+          onChange={handleSwitchChange}
+          checked={isPublicState}
+          name="isPublic"
+          disabled={isPublic}
+          color="primary"
+        />
+        } label="Public Comment" />
+      </FormControl>
+
+      <div>
+        <Button disabled={commentSaving} type="submit" variant="contained" size="small" color="primary">
+         Save
+        </Button>
+        &nbsp;&nbsp;
+        { setEditing &&
+          <Button
+            onClick={() => {
+              setEditing(false);
+            }}
+            disabled={commentSaving}
+            size="small" >
+           Cancel
+          </Button>
+        }
+      </div>
+      </form>
+    </React.Fragment>
+  );
+});

--- a/app/src/components/EditComment.js
+++ b/app/src/components/EditComment.js
@@ -4,7 +4,6 @@ import { withStyles } from '@material-ui/core/styles';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
-import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';

--- a/app/src/components/EditComment.js
+++ b/app/src/components/EditComment.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { compose, withState } from 'recompose';
+import { withStyles } from '@material-ui/core/styles';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+
+const styles = theme => ({
+  control: {
+    float: 'right',
+  },
+  editDropdown: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+  }
+});
+
+const enhanced = compose(
+  withStyles(styles),
+  withState('anchorEl', 'setAnchorEl', null),
+);
+
+export default enhanced(({
+  classes,
+  anchorEl,
+
+  message,
+
+  editing,
+  commentMsg,
+
+  onDeleteClick,
+  setEditing,
+  setCommentMsg,
+  setAnchorEl,
+}) => {
+  return (
+    <React.Fragment>
+      <ClickAwayListener onClickAway={() => {
+        setAnchorEl(null);
+      }}>
+        <React.Fragment>
+          <IconButton
+            size="small"
+            className={classes.editDropdown}
+            aria-owns={anchorEl ? 'simple-menu' : undefined}
+            aria-haspopup="true"
+            onClick={e => setAnchorEl(e.currentTarget)}
+          >
+            <MoreVertIcon fontSize="small" />
+          </IconButton>
+
+          <Menu
+            id="simple-menu"
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={() => {
+              setAnchorEl(null);
+            }}
+          >
+            <MenuItem onClick={() => {
+              setAnchorEl(null);
+              setEditing(true);
+            }}>
+              <EditIcon fontSize="small" aria-label="Edit" />
+              &nbsp;&nbsp;Edit
+            </MenuItem>
+            <MenuItem onClick={() => {
+              setAnchorEl(null);
+              onDeleteClick();
+            }}>
+              <DeleteIcon fontSize="small" aria-label="Delete" />
+              &nbsp;&nbsp;Delete
+            </MenuItem>
+          </Menu>
+        </React.Fragment>
+      </ClickAwayListener>
+    </React.Fragment>
+  )
+});

--- a/app/src/components/Home.js
+++ b/app/src/components/Home.js
@@ -3,6 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { compose } from 'recompose';
 import FeedData from '../containers/FeedData';
 import FeedSubscriptionData from '../containers/FeedSubscriptionData';
+import NewMessage from '../containers/NewMessageWithData';
 import AuthState from '../containers/AuthState';
 import Navbar from '../components/Navbar';
 import ListComments from './ListComments';
@@ -10,7 +11,6 @@ import Notice from './Notice';
 
 const styles = theme => ({
   page: {
-    margin: theme.spacing.unit,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center'
@@ -23,17 +23,35 @@ export default enhanced(({ classes }) => (
   <Navbar>
     <div className={classes.page}>
       <AuthState>
-        {({ isAuthenticated }) => (
+        {({ isAuthenticated, user }) => (
           <React.Fragment>
             { isAuthenticated &&
+              <React.Fragment>
               <FeedSubscriptionData>
-                {props => <Notice {...props} />}
+                { props => (
+                  <React.Fragment>
+                    <Notice {...props} />
+                    <FeedData>{props => {
+                      return <ListComments {...props} />
+                    }}</FeedData>
+                  </React.Fragment>
+                )}
+              </FeedSubscriptionData>
+              <NewMessage author={user} />
+              </React.Fragment>
+            }
+            { !isAuthenticated &&
+              <FeedSubscriptionData>
+                { props => (
+                  <React.Fragment>
+                    <FeedData subscriptionProps={props}>{props => <ListComments {...props} />}</FeedData>
+                  </React.Fragment>
+                )}
               </FeedSubscriptionData>
             }
           </React.Fragment>
         )}
       </AuthState>
-      <FeedData>{props => <ListComments {...props} />}</FeedData>
     </div>
   </Navbar>
 ));

--- a/app/src/components/ListComments.js
+++ b/app/src/components/ListComments.js
@@ -1,13 +1,25 @@
 import React, { Fragment } from 'react';
-import Comment from './Comment';
-import { compose } from 'recompose';
+import Comment from '../containers/CommentWithData';
+import { compose, lifecycle } from 'recompose';
 import renderWhileLoading from '../utils/renderWhileLoading';
 
-const ListComments = ({ comments }) => (
-  <Fragment>
-    {comments &&
-      comments.map(({ id, ...comment }) => <Comment key={id} {...comment} />)}
-  </Fragment>
-);
+const ListComments = props => {
+  const { comments } = props;
+  return (
+    <Fragment>
+      {comments &&
+        comments.map(comment => {
+          return <Comment key={comment.id} {...comment} />
+        })}
+    </Fragment>
+  );
+}
 
-export default compose(renderWhileLoading)(ListComments);
+export default compose(
+  renderWhileLoading,
+  lifecycle({
+    componentDidMount() {
+      this.props.subscribeToNewComments();
+    }
+  }),
+)(ListComments);

--- a/app/src/components/Login.js
+++ b/app/src/components/Login.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { compose, withState } from 'recompose';
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
@@ -10,6 +10,8 @@ import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
+
+import AuthState from '../containers/AuthState';
 
 const styles = theme => ({
   loginContainer: {
@@ -61,7 +63,22 @@ export default enhance(({
   setFormErrorOther,
   setLoginLoading
 }) => (
-    <Card className={classes.loginContainer}>
+    <React.Fragment>
+      <AuthState>
+        {({ isAuthenticated }) => (
+          <React.Fragment>
+            { isAuthenticated &&
+
+              <Redirect
+                to={{
+                  pathname: '/'
+                }}
+              />
+            }
+          </React.Fragment>
+        )}
+      </AuthState>
+      <Card className={classes.loginContainer}>
       { loginLoading &&
         <LinearProgress />
       }
@@ -171,5 +188,6 @@ export default enhance(({
           Sign Up
         </Button>
       </Typography>
-    </Card>
+      </Card>
+    </React.Fragment>
 ));

--- a/app/src/components/Navbar.js
+++ b/app/src/components/Navbar.js
@@ -219,7 +219,7 @@ export default enhanced(({
               paper: classes.drawerPaper,
             }}
             variant="permanent"
-            open
+            open={!mobileOpen}
           >
             <InnerDrawer />
           </Drawer>

--- a/app/src/components/Signup.js
+++ b/app/src/components/Signup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { compose, withState } from 'recompose';
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
@@ -10,6 +10,8 @@ import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
+
+import AuthState from '../containers/AuthState';
 
 const styles = theme => ({
   signupContainer: {
@@ -66,6 +68,21 @@ export default enhance(({
   setFormErrorOther,
   setSignupLoading,
 }) => (
+  <React.Fragment>
+    <AuthState>
+      {({ isAuthenticated }) => (
+        <React.Fragment>
+          { isAuthenticated &&
+
+            <Redirect
+              to={{
+                pathname: '/'
+              }}
+            />
+          }
+        </React.Fragment>
+      )}
+    </AuthState>
     <Card className={classes.signupContainer}>
       { signupLoading &&
         <LinearProgress />
@@ -199,4 +216,5 @@ export default enhance(({
         </Button>
       </Typography>
     </Card>
+  </React.Fragment>
 ));

--- a/app/src/containers/AuthState.js
+++ b/app/src/containers/AuthState.js
@@ -4,12 +4,15 @@ import ClientLoggedInQuery from '../gqlqueries/ClientLoggedIn';
 
 const enhanced = compose(
   graphql(ClientLoggedInQuery,{
-    props: ({ data : { auth }}) => ({
-      isAuthenticated: auth && sessionStorage.getItem('userToken') && auth.isAuthenticated
-    })
+    props: ({ data : { auth }}) => {
+      return ({
+        isAuthenticated: auth && sessionStorage.getItem('userToken') && auth.isAuthenticated,
+        user: auth && sessionStorage.getItem('user') && auth.user
+      })
+    }
   }),
   withProps(({ auth, setAuth } ) => ({
-    auth
+    auth,
   }))
 );
 

--- a/app/src/containers/CommentWithData.js
+++ b/app/src/containers/CommentWithData.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { graphql, Mutation } from 'react-apollo';
+import { compose } from 'react-apollo';
+
+import Comment from '../components/Comment';
+import EditCommentQuery from '../gqlqueries/EditComment';
+import DeleteCommentQuery from '../gqlqueries/DeleteComment';
+
+const CommentMutation = props => {
+  const {
+    id,
+
+    editCommentAction,
+    deleteCommentAction,
+  } = props;
+
+  const handleSubmit = data => {
+    if(data['variables']) {
+      return editCommentAction({
+        variables: data.variables
+      })
+      .then(res => {
+        console.log('Comment edit response!', res)
+      })
+      .catch( e => {
+        console.log('ERROR!', e)
+      });
+    }
+  };
+
+  const handleDeleteClick = () => {
+    return deleteCommentAction({
+      id: id
+    })
+    .then(res => {
+      console.log('res from delete!', res)
+    })
+    .catch(e => {
+      console.log('ERROR!', e)
+    })
+  };
+
+  return (
+    <Mutation mutation={EditCommentQuery}>
+      {() => (
+        <Comment
+          {...props}
+          onDeleteClick={handleDeleteClick}
+          onCommentSave={handleSubmit}
+        />
+      )}
+    </Mutation>
+  );
+};
+
+export default compose(
+  graphql(EditCommentQuery, { name: 'editCommentAction' }),
+  graphql(DeleteCommentQuery, { name: 'deleteCommentAction' }),
+)(CommentMutation);

--- a/app/src/containers/ComposeWithData.js
+++ b/app/src/containers/ComposeWithData.js
@@ -36,6 +36,11 @@ const LoginMutation = props => {
       .then(res => {
         sessionStorage.setItem('userToken', res.data.login.token);
         sessionStorage.setItem('user', JSON.stringify(res.data.login.user));
+        // @TODO this should work but itmermittently fails
+        // I believe it may be related to the container pattern
+        // and the fact that props is being called here from the
+        // parent and interrupting the childs lifecycle
+        props.history.push('/');
       })
       .catch( e => {
         return { errors: parseResponseError(e.graphQLErrors) };

--- a/app/src/containers/EditCommentWithData.js
+++ b/app/src/containers/EditCommentWithData.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { graphql, Mutation } from 'react-apollo';
+import { graphql } from 'react-apollo';
 import { compose } from 'react-apollo';
 
 import EditComment from '../components/EditComment';

--- a/app/src/containers/EditCommentWithData.js
+++ b/app/src/containers/EditCommentWithData.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { graphql, Mutation } from 'react-apollo';
+import { compose } from 'react-apollo';
+
+import EditComment from '../components/EditComment';
+
+import DeleteCommentQuery from '../gqlqueries/DeleteComment';
+
+const EditCommentMutation = props => {
+  const {
+    deleteCommentAction,
+    setEditing,
+  } = props;
+
+  const handleSaveClick = () => {
+    setEditing(false);
+  };
+
+  const handleDeleteClick = () => {
+    return deleteCommentAction({
+      id: props.id
+    })
+    .then(res => {
+      console.log('res from delete!', res)
+    })
+    .catch(e => {
+      console.log('ERROR!', e)
+    })
+  };
+
+  return (
+    <EditComment
+      {...props}
+      onDeleteClick={handleDeleteClick}
+      onSaveClick={handleSaveClick}
+    />
+  );
+};
+
+export default compose(
+  graphql(DeleteCommentQuery, { name: 'deleteCommentAction' }),
+)(EditCommentMutation);

--- a/app/src/containers/FeedData.js
+++ b/app/src/containers/FeedData.js
@@ -1,13 +1,35 @@
 import { graphql } from 'react-apollo';
 import { compose, withProps, toRenderProps } from 'recompose';
 import FeedDataQuery from '../gqlqueries/FeedData';
+import FeedSubscription from '../gqlqueries/FeedSubscription';
 
-const enhanced = compose(
-  graphql(FeedDataQuery),
-  withProps(({ data: { loading, feed } }) => ({
-    loading: loading,
-    comments: feed
-  }))
-);
+ const enhanced = compose(
+   graphql(FeedDataQuery),
+   withProps(({ data: { subscribeToMore, loading, feed } }) => {
+      return {
+        subscribeToNewComments: () => {
+          return subscribeToMore({
+            document: FeedSubscription,
+            updateQuery: (prev, { subscriptionData }) => {
+              if (!subscriptionData.data) return prev;
+              const targetFeedItem = subscriptionData.data.feedSubscription.node;
+              switch(subscriptionData.data.feedSubscription.mutation) {
+                case 'CREATED':
+                  return Object.assign({}, prev, { feed: [targetFeedItem, ...prev.feed] });
+                case 'UPDATED':
+                  return Object.assign({}, prev, { feed: prev.feed.map( item => { return item.id === subscriptionData.data.feedSubscription.previousValues.id.replace('StringIdGCValue(','').replace(')','') ? targetFeedItem : item } ) })
+                case 'DELETED':
+                  return Object.assign({}, prev, { feed: prev.feed.filter( item => { return item.id !== subscriptionData.data.feedSubscription.previousValues.id.replace('StringIdGCValue(','').replace(')','') }) })
+                default:
+                  return prev
+              }
+            }
+          })
+        },
+        loading: loading,
+        comments: feed,
+      }
+   }),
+ );
 
-export default toRenderProps(enhanced);
+ export default toRenderProps(enhanced);

--- a/app/src/containers/NewMessageWithData.js
+++ b/app/src/containers/NewMessageWithData.js
@@ -4,17 +4,12 @@ import { compose } from 'react-apollo';
 
 import Compose from '../components/Compose';
 import NewCommentQuery from '../gqlqueries/NewComment';
-import DeleteCommentQuery from '../gqlqueries/DeleteComment';
 
 const NewMessageMutation = props => {
   const {
-    id,
     author,
-    editing,
 
     newCommentAction,
-    deleteCommentAction,
-    refetch,
   } = props;
 
   const handleSubmit = data => {
@@ -23,8 +18,7 @@ const NewMessageMutation = props => {
         variables: data.variables
       })
       .then(res => {
-        console.log('Comment edit res!!!', res)
-        refetch();
+        console.log('Comment edit res', res)
       })
       .catch( e => {
 

--- a/app/src/containers/NewMessageWithData.js
+++ b/app/src/containers/NewMessageWithData.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { graphql, Mutation } from 'react-apollo';
+import { compose } from 'react-apollo';
+
+import Compose from '../components/Compose';
+import NewCommentQuery from '../gqlqueries/NewComment';
+import DeleteCommentQuery from '../gqlqueries/DeleteComment';
+
+const NewMessageMutation = props => {
+  const {
+    id,
+    author,
+    editing,
+
+    newCommentAction,
+    deleteCommentAction,
+    refetch,
+  } = props;
+
+  const handleSubmit = data => {
+    if(data['variables']) {
+      return newCommentAction({
+        variables: data.variables
+      })
+      .then(res => {
+        console.log('Comment edit res!!!', res)
+        refetch();
+      })
+      .catch( e => {
+
+      });
+    }
+  };
+
+  return (
+    <Mutation mutation={NewCommentQuery}>
+      {() => (
+        <Compose
+          onCommentSave={handleSubmit}
+          author={author}
+        />
+      )}
+    </Mutation>
+  );
+};
+
+export default compose(
+  graphql(NewCommentQuery, { name: 'newCommentAction' }),
+)(NewMessageMutation);

--- a/app/src/containers/SignupWithData.js
+++ b/app/src/containers/SignupWithData.js
@@ -52,7 +52,7 @@ const SignupMutation = props => {
         })
         .then(res => {
           sessionStorage.setItem('userToken', res.data.login.token);
-          props.history.push('/');
+          sessionStorage.setItem('user', JSON.stringify(res.data.login.user));
         })
         .catch( e => {
           return {error: 'invalid user credentials'};

--- a/app/src/gqlqueries/AllFeedData.js
+++ b/app/src/gqlqueries/AllFeedData.js
@@ -7,11 +7,7 @@ export default gql`
       isPublic
       message
       createdAt
-      author {
-        id
-        email
-        name
-      }
+      author { id }
     }
   }
 `;

--- a/app/src/gqlqueries/ClientLoggedIn.js
+++ b/app/src/gqlqueries/ClientLoggedIn.js
@@ -4,6 +4,7 @@ export default gql`
   query {
     auth @client {
       isAuthenticated
+      user
     }
   }
 `;

--- a/app/src/gqlqueries/DeleteComment.js
+++ b/app/src/gqlqueries/DeleteComment.js
@@ -1,0 +1,10 @@
+import gql from 'graphql-tag';
+
+export default gql`
+mutation deleteComment($id: ID!){
+  deleteComment (id: $id) {
+    id
+    message
+  }
+}
+`;

--- a/app/src/gqlqueries/EditComment.js
+++ b/app/src/gqlqueries/EditComment.js
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+export default gql`
+mutation editComment($id: ID!, $message: String!, $isPublic: Boolean!){
+  editComment (id: $id, message: $message, isPublic: $isPublic) {
+    id
+    message
+    isPublic
+  }
+}
+`;

--- a/app/src/gqlqueries/FeedSubscription.js
+++ b/app/src/gqlqueries/FeedSubscription.js
@@ -6,6 +6,13 @@ export default gql`
       mutation
       node {
         id
+        author {
+          id
+          email
+          name
+        }
+        isPublic
+        createdAt
         message
         updatedAt
       }

--- a/app/src/gqlqueries/Logout.js
+++ b/app/src/gqlqueries/Logout.js
@@ -1,10 +1,11 @@
 import gql from 'graphql-tag';
 
 export default gql`
-  mutation setAuth($isAuthenticated: Bool!){
-    setAuth (isAuthenticated: $isAuthenticated) @client {
+  mutation setAuth($isAuthenticated: Boolean!, $user: Object!){
+    setAuth (isAuthenticated: $isAuthenticated, user: $user) @client {
       auth {
         isAuthenticated
+        user
       }
     }
   }

--- a/app/src/gqlqueries/NewComment.js
+++ b/app/src/gqlqueries/NewComment.js
@@ -1,0 +1,28 @@
+import gql from 'graphql-tag';
+
+export default gql`
+mutation createComment($message: String!, $isPublic: Boolean!){
+  createComment(message: $message, isPublic: $isPublic){
+    id
+    message
+    createdAt
+    isPublic
+    children {
+      id
+      author {
+        id
+      }
+      message
+      createdAt
+    }
+    parent {
+      id
+      message
+      createdAt
+    }
+    author {
+      id
+    }
+  }
+}
+`;

--- a/app/src/providers/DataProvider.js
+++ b/app/src/providers/DataProvider.js
@@ -9,22 +9,13 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { setContext } from 'apollo-link-context';
 import { withClientState } from 'apollo-link-state';
 
-const setAuth = (_, { isAuthenticated }, { cache }) => {
+const setAuth = (_, props, { cache }) => {
+  const { isAuthenticated, user } = props;
   const data = {
     auth: {
       __typename: 'Auth',
-      isAuthenticated
-    },
-  };
-  cache.writeData({ data });
-  return null;
-};
-
-const setSignupLoading = (_, { loading }, { cache }) => {
-  const data = {
-    signupState: {
-      __typename: 'UiState',
-      loading
+      isAuthenticated,
+      user,
     },
   };
   cache.writeData({ data });
@@ -37,7 +28,10 @@ const HTTP_URL = 'http://localhost:4000';
 const wsLink = new WebSocketLink({
   uri: WS_URL,
   options: {
-    reconnect: true
+    reconnect: true,
+    connectionParams: {
+      Authorization : sessionStorage.getItem('userToken') ? `Bearer ${sessionStorage.getItem('userToken')}` : '',
+    }
   }
 });
 
@@ -67,6 +61,7 @@ const defaultState = {
   auth: {
     __typename: 'Auth',
     isAuthenticated: !!sessionStorage.getItem('userToken'),
+    user: JSON.parse(sessionStorage.getItem('user')) || null,
   }
 };
 
@@ -75,7 +70,6 @@ const stateLink = withClientState({
   resolvers: {
     Mutation: {
       setAuth,
-      setSignupLoading,
     },
   },
   defaults: defaultState

--- a/server/src/resolvers/Subscription.js
+++ b/server/src/resolvers/Subscription.js
@@ -1,13 +1,18 @@
+const { getUserIdOptional } = require('../utils');
+
 const Subscription = {
   feedSubscription: {
     subscribe: (parent, args, ctx, info) => {
-      // TODO: handle authenticated subscriptions
+      const userId = getUserIdOptional(ctx);
+
+      const query =
+        userId === -1
+          ? { isPublic: true }
+          : { author: { id: userId } };
       return ctx.db.subscription.comment(
         {
           where: {
-            node: {
-              isPublic: true
-            }
+            node: query
           }
         },
         info

--- a/server/src/resolvers/Subscription.js
+++ b/server/src/resolvers/Subscription.js
@@ -8,7 +8,7 @@ const Subscription = {
       const query =
         userId === -1
           ? { isPublic: true }
-          : { author: { id: userId } };
+          : { OR: [{ author: { id: userId } }, { isPublic: true } ] };
       return ctx.db.subscription.comment(
         {
           where: {

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -1,7 +1,12 @@
 const jwt = require('jsonwebtoken');
 
+function getAuthorization(ctx) {
+  if (ctx.request) return ctx.request.get('Authorization');
+  if (ctx.connection) return ctx.connection.context['Authorization'];
+}
+
 function getUserId(ctx, optional = false) {
-  const Authorization = ctx.request.get('Authorization');
+  const Authorization = getAuthorization(ctx);
   if (Authorization) {
     const token = Authorization.replace('Bearer ', '');
     const { userId } = jwt.verify(token, process.env.APP_SECRET);


### PR DESCRIPTION
This is the first of two or more PRs to address comment CRUD capabilities as well as comment WSS connection, upgrading both the server and client to handle authenticated websocket requests thereby enabling `subscribeToMore` to work for both public and private queries

Adds the following features:

- [x] Enables authorization on websocket connections to fix Subscription query for non `isPublic` comments (a bug in the starting project wouldn't allow `subscribeToMore` to work properly due to lack of WSS connection authorization, so only `isPublic = true` comments would be picked up by `subscribeToMore`
- [x]  Uses `subscribeToMore` for websocket connected listening and updating of main feed data
- [x] Adds `user` to <AuthState> component and is used for comment ownership, conditional editing capabilities, UI look / feel, etc.
- [x] Adds <Compose> component to be re-used for all areas where comments can be edited & saved
- [x] Improves look / feel of comments a bit
- [x] Fixes login / singup redirection again to use better approach with <Redirect> component